### PR TITLE
Switch to Github Container Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,17 +2,14 @@ name: Docker
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
     branches:
       - master
       - dev
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 
 env:
-  IMAGE_NAME: icd-10-api
+  TMP_IMAGE_NAME: tmp-image
 
 jobs:
   push:
@@ -22,14 +19,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+        run: docker build . --file Dockerfile --tag $TMP_IMAGE_NAME
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository }}
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
@@ -49,5 +46,5 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker tag $TMP_IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ Want an ICD 10 api of your own? The easiest way is to deploy our docker containe
 
 
 ### Deployment
-1. [Log into the GitHub package registry for Docker](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages).
 1. Start the container with a single command
     ```
-    docker run --name icd-10-api -p 3000:3000 -d docker.pkg.github.com/dot-base/icd-10-api/icd-10-api:latest
+    docker run --name icd-10-api -p 3000:3000 -d ghcr.io/dot-base/icd-10-api:latest
     ```
 1. Done and dusted 🎉. The ICD 10 rest api is available on port 3000.
 


### PR DESCRIPTION
### 🚀 Description
This PR changes the container registry for docker from github packages to the newly introduced [Github Container Registy (GHCR)](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/about-github-container-registry)

### 🧰 Technical Solution
[What did you add / change to create this feature?]
- [x] Correct github action to use GHCR

### ‼ Known Issues
The Github Container Registy is still in the open beta phase for now.