### PR TITLE
Enforce fhir types version 4.0.32 to avoid broken versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "production": "node -r tsconfig-paths/register build/server.js"
   },
   "dependencies": {
-    "@ahryman40k/ts-fhir-types": "^4.0.32",
+    "@ahryman40k/ts-fhir-types": "4.0.32",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",


### PR DESCRIPTION
This PR avoids broken builds because of a broken fhir type version.

### 🚒 Technical Solution
[How did you fix this bug?]
- [ ] As done in other repositories it was necessary to enforce version 4.0.32 for the fhir types library
