### PR TITLE
Set base url to /api/icd10

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ async function startApiServer(): Promise<void> {
     throw error;
   }
 
-  app.use("/icd10", icd10Router);
+  app.use("/api/icd10", icd10Router);
 
   app.listen(port);
   console.log(`Server is listening on port ${port}`);


### PR DESCRIPTION
This PR unifies the bae url of the service.

### 🚒 Technical Solution
[How did you fix this bug?]
- [x] Set base url to /api/icd10
