### PR TITLE
Set node version to node 14 lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
-      - name: Set up nodejs v12
+      - name: Set up nodejs v14
         uses: actions/setup-node@v1
         with:
-          node-version: '12'
+          node-version: '14'
 
       - name: Install dependencies
         run: npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:lts-alpine AS builder
 WORKDIR /usr/src/node-builder
 COPY . .
 RUN npm install && \
@@ -8,7 +8,7 @@ RUN npm install && \
     mv ./tsconfig.json ./builder/tsconfig.json && \
     mv ./package.json ./builder/package.json
 
-FROM node:alpine
+FROM node:lts-alpine
 WORKDIR /usr/src/project
 COPY --from=builder /usr/src/node-builder/builder .
 RUN npm install --production


### PR DESCRIPTION
This PR fixes the broken docker build which fails because of building on node 15 (latest) instead of the 14 (lts) version.
