### PR TITLE
Bugfix - Set Explicit FHIR types version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "production": "node -r tsconfig-paths/register build/server.js"
   },
   "dependencies": {
-    "@ahryman40k/ts-fhir-types": "^4.0.32",
+    "@ahryman40k/ts-fhir-types": "4.0.32",
     "@sentry/node": "^5.29.0",
     "@sentry/tracing": "^5.29.0",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
This PR explicitly sets an old version of the FHIR types library because the current version is still broken.

### 🚒 Technical Solution
[How did you fix this bug?]
- [ ] Set fhir types version in package json to 4.0.32
