### PR TITLE
chore: improve extension removal readability

### DIFF
--- a/src/controller/icd10.ts
+++ b/src/controller/icd10.ts
@@ -62,7 +62,10 @@ export class ICD10Controller {
   private static removeExtensions(
     res: Fuse.FuseResult<ICodeSystem_Concept>[]
   ): Fuse.FuseResult<ICodeSystem_Concept>[] {
-    res.forEach((r) => (r.item.extension = r.item.modifierExtension = undefined));
+    res.forEach((r) => {
+      r.item.extension = undefined;
+      r.item.modifierExtension = undefined;
+    });
     return res;
   }
 }


### PR DESCRIPTION
# Ticket 🎫

This closes #65.

# Description 📖
This simply removes the double assignment syntax, but does not change any functionality.

# Checklist ✅
- [x] My changes generate no new warnings
- [x] Made corresponding changes to the documentation if applicable
- [x] Commented my code, particularly in hard-to-understand areas if applicable
- [x] Performed a self-review of my own changes
