### PR TITLE
fix: home needs to be valid npm cache location

### DIFF
--- a/dev-overlay.yml
+++ b/dev-overlay.yml
@@ -5,6 +5,8 @@ services:
     image: node:18.12.1-alpine
     user: ${USERID}
     working_dir: /var/workspace
+    environment:
+            HOME: "/tmp"
     volumes:
       - ${DEV_OVERLAY_DIR}:/var/workspace/:cached
     ports:

--- a/dev-overlay.yml
+++ b/dev-overlay.yml
@@ -6,7 +6,7 @@ services:
     user: ${USERID}
     working_dir: /var/workspace
     environment:
-            HOME: "/tmp"
+            HOME: "/tmp" # This is needed so npm can create the cache at the default location ~/.npm
     volumes:
       - ${DEV_OVERLAY_DIR}:/var/workspace/:cached
     ports:


### PR DESCRIPTION
# Ticket 🎫

This closes #73.

# Description 📖
Changes the home dir in the dev overlay to `/tmp` just like for the medical-dashboard.

# How to Test? 🧪

See bug reproduction steps.

# References (optional) 🔗

See issue references.

# Checklist ✅
- [x] My changes generate no new warnings
- [x] Made corresponding changes to the documentation if applicable
- [x] Commented my code, particularly in hard-to-understand areas if applicable
- [x] Performed a self-review of my own changes
