### PR TITLE
chore: store npm cache on host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# macOS
 .DS_Store
+
+# npm
+.npm_cache
 node_modules
 build
 /dist

--- a/dev-overlay.yml
+++ b/dev-overlay.yml
@@ -6,7 +6,8 @@ services:
     user: ${USERID}
     working_dir: /var/workspace
     environment:
-            HOME: "/tmp" # This is needed so npm can create the cache at the default location ~/.npm
+      # default npm cache location (~/.npm) is not writeable in the container
+      npm_config_cache: /var/workspace/.npm_cache
     volumes:
       - ${DEV_OVERLAY_DIR}:/var/workspace/:cached
     ports:


### PR DESCRIPTION
# Ticket 🎫

This is part of https://github.com/dot-base/deployments/issues/184

# Description 📖
Changes the npm cache location in the dev-overlay, so that the cache is stored on the docker host.

# How to Test? 🧪

Checkout and run the dev-overlay. See cache directory appear in your local repo folder.
